### PR TITLE
Add tests for highlighting decorations

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -143,18 +143,18 @@ The plugin will integrate directly with the **JetBrains AI Platform** using HTTP
 
 ### Phase 3: User Interface (Medium Priority)
 
-- [ ] **Create CSS styles for error highlighting** (CRITICAL)
+- [x] **Create CSS styles for error highlighting** (CRITICAL)
   - Add `.grazie-plugin-grammar-error` class with red wavy underline
   - Add `.grazie-plugin-spelling-error` class with blue wavy underline
   - Create `.grazie-plugin-error-high-confidence` and `.grazie-plugin-error-low-confidence` variants
   - Style tooltip containers with `.grazie-plugin-tooltip` class
   - Ensure styles work with both light and dark Obsidian themes
-- [ ] Implement underline decorations for errors with different styles
+- [x] Implement underline decorations for errors with different styles
   - Use `Decoration.mark()` with `class` attribute for CSS styling
   - Map `CorrectionServiceType` to appropriate CSS classes
   - Apply confidence level styling based on `ConfidenceLevel` enum
   - Create decoration specs for grammar, spelling, and mixed errors
-- [ ] Add different styles for grammar vs spelling errors
+- [x] Add different styles for grammar vs spelling errors
   - Grammar errors: red wavy underline (`text-decoration: underline wavy red`)
   - Spelling errors: blue wavy underline (`text-decoration: underline wavy blue`)
   - Mixed errors: purple wavy underline for combined issues

--- a/src/__tests__/decorations-view.test.ts
+++ b/src/__tests__/decorations-view.test.ts
@@ -1,0 +1,67 @@
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { grammarDecorationsExtension, setGrammarProblems, GrammarProblemWithPosition } from "../editor/decorations";
+import { Problem, ProblemCategory, CorrectionServiceType, ConfidenceLevel } from "../jetbrains-ai";
+
+describe("grammarDecorationsExtension", () => {
+	function createView(doc: string): { view: EditorView; parent: HTMLElement } {
+		const state = EditorState.create({
+			doc,
+			extensions: [grammarDecorationsExtension()],
+		});
+		const parent = document.createElement("div");
+		const view = new EditorView({ state, parent });
+		return { view, parent };
+	}
+
+	function makeProblem(
+		from: number,
+		to: number,
+		category: ProblemCategory,
+		service: CorrectionServiceType,
+		confidence: ConfidenceLevel
+	): GrammarProblemWithPosition {
+		const problem: Problem = {
+			message: "test",
+			info: {
+				id: { id: "1" },
+				category,
+				service,
+				displayName: "test",
+				confidence,
+			},
+			highlighting: {
+				always: [{ start: from, endExclusive: to }],
+				onHover: [],
+			},
+			fixes: [],
+		};
+		return { problem, from, to, sentenceIndex: 0, sentenceOffset: from };
+	}
+
+	it("adds spelling error classes", () => {
+		const { view, parent } = createView("This is tset text.");
+		const p = makeProblem(8, 12, ProblemCategory.SPELLING, CorrectionServiceType.SPELL, ConfidenceLevel.HIGH);
+		view.dispatch({ effects: setGrammarProblems.of([p]) });
+
+		const span = parent.querySelector<HTMLElement>(".grazie-plugin-spelling-error");
+		expect(span).not.toBeNull();
+		if (span) {
+			expect(span.textContent).toBe("tset");
+			expect(span.classList.contains("grazie-plugin-error-high-confidence")).toBe(true);
+		}
+	});
+
+	it("adds grammar error classes with low confidence", () => {
+		const { view, parent } = createView("Sentence with eror.");
+		const p = makeProblem(14, 18, ProblemCategory.GRAMMAR, CorrectionServiceType.MLEC, ConfidenceLevel.LOW);
+		view.dispatch({ effects: setGrammarProblems.of([p]) });
+
+		const span = parent.querySelector<HTMLElement>(".grazie-plugin-grammar-error");
+		expect(span).not.toBeNull();
+		if (span) {
+			expect(span.textContent).toBe("eror");
+			expect(span.classList.contains("grazie-plugin-error-low-confidence")).toBe(true);
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- add tests for decoration CSS classes
- mark CSS highlighting tasks as done in IMPLEMENTATION_PLAN

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_6879499b18f48332866f760aa7ac7a76