### PR TITLE
Implement language & sentence caching

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -31,21 +31,18 @@ The plugin will integrate directly with the **JetBrains AI Platform** using HTTP
 ### Core Components
 
 1. **JetBrains AI Platform Client**
-
    - Custom TypeScript HTTP client for API communication
    - Configuration management (staging/production, regional URLs)
    - Authentication token handling (user tokens for development)
    - Support for GEC v3 and v4 APIs (with markup exclusions)
 
 2. **Grammar Checking Engine**
-
    - Integration with JetBrains AI Platform GEC service
    - Support for English, German, Russian, Ukrainian
    - Three-tier checking: MLEC (ML), SPELL (dictionary), RULE (rules)
    - Sentence-based processing with problem detection
 
 3. **Obsidian Integration Layer**
-
    - Editor extensions for real-time checking
    - CodeMirror 6 view plugins for decorations
    - Settings panel for configuration
@@ -130,11 +127,12 @@ The plugin will integrate directly with the **JetBrains AI Platform** using HTTP
   - Add debouncing using `setTimeout` with 500ms delay
   - Trigger grammar check on `EditorView.updateListener`
   - Manage plugin state through `StateField.define()`
-- [ ] Add LRU cache for language detection results
+- [x] Add LRU cache for language detection results
   - Implement `Map` with size limit (e.g., 100 entries)
   - Cache key: document content hash, value: detected language
   - Implement cache eviction when size exceeds limit
   - Store in `LanguageDetectorService` class
+  - Added sentence-level API response cache to minimize repeated requests
 - [ ] Implement CodeMirror 6 state management for decorations
   - Create `StateField` for storing grammar problems and decorations
   - Implement state transactions for adding/removing decorations
@@ -329,15 +327,12 @@ Based on user experience analysis, we should prioritize:
 ## Expected Challenges
 
 1. **Performance**: Real-time checking without lag
-
    - _Solution_: Implement debouncing and incremental processing
 
 2. **Accuracy**: Handling markdown-specific syntax
-
    - _Solution_: Use exclusions API to ignore markdown syntax
 
 3. **Authentication**: Managing user tokens securely
-
    - _Solution_: Secure token storage and refresh handling
 
 4. **User Experience**: Non-intrusive error highlighting

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The project is usable but still under active development. Core grammar checking 
 - Hover tooltips and clickable suggestions
 - Automatic grammar check when a file is opened
 - Manual check command available from the ribbon
+- Language detection and sentence-level results are cached to reduce API usage
 
 ### Planned Features 🔄
 

--- a/src/__tests__/grammar-checker-cache.test.ts
+++ b/src/__tests__/grammar-checker-cache.test.ts
@@ -1,0 +1,50 @@
+import { GrammarCheckerService } from "../services/grammar-checker";
+import { DEFAULT_SETTINGS, GraziePluginSettings } from "../settings/types";
+import { JetBrainsAIClient } from "../jetbrains-ai";
+import { AuthenticationService } from "../jetbrains-ai/auth";
+
+const mockCheckGrammar = jest.fn(({ sentences }: { sentences: string[] }) =>
+	Promise.resolve(sentences.map(s => ({ sentence: s, language: "ENGLISH", problems: [] })))
+);
+
+jest.mock("../jetbrains-ai", () => {
+	return {
+		JetBrainsAIClient: class {
+			initialize = jest.fn();
+			checkGrammar = mockCheckGrammar;
+			constructor(..._args: unknown[]) {}
+			static createWithUserToken() {
+				return {
+					initialize: jest.fn(),
+					checkGrammar: mockCheckGrammar,
+				} as unknown as JetBrainsAIClient;
+			}
+		},
+		CorrectionServiceType: { MLEC: "MLEC", SPELL: "SPELL", RULE: "RULE" },
+		ConfidenceLevel: { HIGH: "HIGH", LOW: "LOW" },
+	};
+});
+
+const mockAuthService: AuthenticationService = {
+	getAuthenticatedToken: () => "token",
+} as unknown as AuthenticationService;
+
+describe("GrammarCheckerService sentence cache", () => {
+	let settings: GraziePluginSettings;
+
+	beforeEach(() => {
+		settings = { ...DEFAULT_SETTINGS };
+		mockCheckGrammar.mockClear();
+	});
+
+	it("should reuse cached sentences", async () => {
+		const service = new GrammarCheckerService(settings, mockAuthService);
+		await service.initialize();
+
+		const text = "First sentence. Second sentence.";
+		await service.checkText(text);
+		await service.checkText(text);
+
+		expect(mockCheckGrammar).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/__tests__/language-detector-cache.test.ts
+++ b/src/__tests__/language-detector-cache.test.ts
@@ -1,0 +1,19 @@
+import { LanguageDetectorService } from "../services/language-detector";
+import { franc } from "franc-min";
+
+jest.mock("franc-min", () => ({ franc: jest.fn(() => "eng") }));
+
+const mockedFranc = franc as jest.Mock;
+
+describe("LanguageDetectorService caching", () => {
+	it("should cache detection results", () => {
+		const service = new LanguageDetectorService(10);
+		const text = "This is an example sentence that should be detected.";
+		const first = service.detectLanguage(text);
+		const second = service.detectLanguage(text);
+
+		expect(first).toEqual(second);
+		expect(mockedFranc).toHaveBeenCalledTimes(1);
+		expect(service.getCacheSize()).toBe(1);
+	});
+});

--- a/src/services/lru-cache.ts
+++ b/src/services/lru-cache.ts
@@ -1,0 +1,35 @@
+export class LRUCache<K, V> {
+	private map = new Map<K, V>();
+	constructor(private limit: number) {}
+
+	get(key: K): V | undefined {
+		const value = this.map.get(key);
+		if (value !== undefined) {
+			this.map.delete(key);
+			this.map.set(key, value);
+		}
+		return value;
+	}
+
+	set(key: K, value: V): void {
+		if (this.map.has(key)) {
+			this.map.delete(key);
+		} else if (this.map.size >= this.limit) {
+			const oldestKey = this.map.keys().next().value as K | undefined;
+			if (oldestKey !== undefined) {
+				this.map.delete(oldestKey);
+			}
+		}
+		this.map.set(key, value);
+	}
+
+	size(): number {
+		return this.map.size;
+	}
+}
+
+import { createHash } from "crypto";
+
+export function hashString(text: string): string {
+	return createHash("sha1").update(text).digest("hex");
+}


### PR DESCRIPTION
## Summary
- add LRUCache utility and hashing helper
- cache language detection results
- reuse cached sentences to skip API calls
- document caching in README
- mark caching step complete in implementation plan
- add tests for new caching behaviour

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_687abe5396c083329229f3aef9c0640e