### PR TITLE
fix: grammar check sentences ending with newlines but no punctuation

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -31,18 +31,21 @@ The plugin will integrate directly with the **JetBrains AI Platform** using HTTP
 ### Core Components
 
 1. **JetBrains AI Platform Client**
+
    - Custom TypeScript HTTP client for API communication
    - Configuration management (staging/production, regional URLs)
    - Authentication token handling (user tokens for development)
    - Support for GEC v3 and v4 APIs (with markup exclusions)
 
 2. **Grammar Checking Engine**
+
    - Integration with JetBrains AI Platform GEC service
    - Support for English, German, Russian, Ukrainian
    - Three-tier checking: MLEC (ML), SPELL (dictionary), RULE (rules)
    - Sentence-based processing with problem detection
 
 3. **Obsidian Integration Layer**
+
    - Editor extensions for real-time checking
    - CodeMirror 6 view plugins for decorations
    - Settings panel for configuration
@@ -327,12 +330,15 @@ Based on user experience analysis, we should prioritize:
 ## Expected Challenges
 
 1. **Performance**: Real-time checking without lag
+
    - _Solution_: Implement debouncing and incremental processing
 
 2. **Accuracy**: Handling markdown-specific syntax
+
    - _Solution_: Use exclusions API to ignore markdown syntax
 
 3. **Authentication**: Managing user tokens securely
+
    - _Solution_: Secure token storage and refresh handling
 
 4. **User Experience**: Non-intrusive error highlighting

--- a/src/__tests__/unterminated-sentences-core.test.ts
+++ b/src/__tests__/unterminated-sentences-core.test.ts
@@ -1,0 +1,158 @@
+import { GrammarCheckerService } from "../services/grammar-checker";
+import { DEFAULT_SETTINGS, GraziePluginSettings } from "../settings/types";
+import { JetBrainsAIClient } from "../jetbrains-ai";
+import { AuthenticationService } from "../jetbrains-ai/auth";
+
+const mockCheckGrammar = jest.fn();
+
+jest.mock("../jetbrains-ai", () => {
+	return {
+		JetBrainsAIClient: class {
+			initialize = jest.fn();
+			checkGrammar = mockCheckGrammar;
+			constructor(..._args: unknown[]) {}
+			static createWithUserToken() {
+				return {
+					initialize: jest.fn(),
+					checkGrammar: mockCheckGrammar,
+				} as unknown as JetBrainsAIClient;
+			}
+		},
+		CorrectionServiceType: { MLEC: "MLEC", SPELL: "SPELL", RULE: "RULE" },
+		ConfidenceLevel: { HIGH: "HIGH", LOW: "LOW" },
+	};
+});
+
+const mockAuthService: AuthenticationService = {
+	getAuthenticatedToken: () => "token",
+} as unknown as AuthenticationService;
+
+describe("Unterminated Sentences Bug Fix - Core Cases", () => {
+	let settings: GraziePluginSettings;
+	let service: GrammarCheckerService;
+
+	beforeEach(() => {
+		settings = { ...DEFAULT_SETTINGS };
+		mockCheckGrammar.mockClear();
+		service = new GrammarCheckerService(settings, mockAuthService);
+	});
+
+	test("should grammar check sentences that end with newlines but no punctuation", async () => {
+		// This is the exact scenario described in the bug report
+		const text =
+			"This sentence has no punctuation whatsoever and ends with a newline character\nThis second sentence has proper punctuation.";
+
+		let receivedSentences: string[] = [];
+		mockCheckGrammar.mockImplementation((request: { sentences: string[] }) => {
+			receivedSentences = request.sentences;
+			return Promise.resolve({
+				corrections: request.sentences.map(s => ({ sentence: s, language: "ENGLISH", problems: [] })),
+			});
+		});
+
+		await service.initialize();
+		await service.checkText(text);
+
+		// Both sentences should be grammar checked individually
+		expect(receivedSentences).toHaveLength(2);
+		expect(receivedSentences).toContain(
+			"This sentence has no punctuation whatsoever and ends with a newline character."
+		);
+		expect(receivedSentences).toContain("This second sentence has proper punctuation.");
+	});
+
+	test("should handle paragraph breaks with unterminated sentences", async () => {
+		const markdown = `This is the first paragraph without any punctuation
+
+This is the second paragraph that also lacks punctuation
+
+This final paragraph has punctuation.`;
+
+		let receivedSentences: string[] = [];
+		mockCheckGrammar.mockImplementation((request: { sentences: string[] }) => {
+			receivedSentences = request.sentences;
+			return Promise.resolve({
+				corrections: request.sentences.map(s => ({ sentence: s, language: "ENGLISH", problems: [] })),
+			});
+		});
+
+		await service.initialize();
+		await service.checkText(markdown);
+
+		// All three paragraphs should be grammar checked
+		expect(receivedSentences).toHaveLength(3);
+		expect(receivedSentences).toContain("This is the first paragraph without any punctuation.");
+		expect(receivedSentences).toContain("This is the second paragraph that also lacks punctuation.");
+		expect(receivedSentences).toContain("This final paragraph has punctuation.");
+	});
+
+	test("should preserve normal punctuation-based sentence splitting", async () => {
+		const text =
+			"This sentence ends properly. This one does too! And this one as well? This one lacks punctuation completely\nBut this final one has punctuation.";
+
+		let receivedSentences: string[] = [];
+		mockCheckGrammar.mockImplementation((request: { sentences: string[] }) => {
+			receivedSentences = request.sentences;
+			return Promise.resolve({
+				corrections: request.sentences.map(s => ({ sentence: s, language: "ENGLISH", problems: [] })),
+			});
+		});
+
+		await service.initialize();
+		await service.checkText(text);
+
+		// Should detect all sentences correctly
+		expect(receivedSentences).toHaveLength(5);
+		expect(receivedSentences).toContain("This sentence ends properly.");
+		expect(receivedSentences).toContain("This one does too!");
+		expect(receivedSentences).toContain("And this one as well?");
+		expect(receivedSentences).toContain("This one lacks punctuation completely.");
+		expect(receivedSentences).toContain("But this final one has punctuation.");
+	});
+
+	test("should not over-split sentences with proper grammar", async () => {
+		// Test that we don't create false positives with normal sentences
+		const text = "JavaScript and TypeScript are programming languages. Python and Java are also popular.";
+
+		let receivedSentences: string[] = [];
+		mockCheckGrammar.mockImplementation((request: { sentences: string[] }) => {
+			receivedSentences = request.sentences;
+			return Promise.resolve({
+				corrections: request.sentences.map(s => ({ sentence: s, language: "ENGLISH", problems: [] })),
+			});
+		});
+
+		await service.initialize();
+		await service.checkText(text);
+
+		// Should not over-split - these are complete sentences
+		expect(receivedSentences).toHaveLength(2);
+		expect(receivedSentences).toContain("JavaScript and TypeScript are programming languages.");
+		expect(receivedSentences).toContain("Python and Java are also popular.");
+	});
+
+	test("should handle the exact user reported case", async () => {
+		// This is the exact case the user reported not working
+		const text =
+			"If a sentence doesn't have a full stop at the end, it's not being correctedd\nNow, I think I neeed to fix this bug";
+
+		let receivedSentences: string[] = [];
+		mockCheckGrammar.mockImplementation((request: { sentences: string[] }) => {
+			receivedSentences = request.sentences;
+			console.log("API received sentences:", receivedSentences);
+			return Promise.resolve({
+				corrections: request.sentences.map(s => ({ sentence: s, language: "ENGLISH", problems: [] })),
+			});
+		});
+
+		await service.initialize();
+		await service.checkText(text);
+
+		// Both sentences should be detected and sent for grammar checking
+		expect(receivedSentences).toHaveLength(2);
+		expect(receivedSentences).toContain(
+			"If a sentence doesn't have a full stop at the end, it's not being correctedd."
+		);
+		expect(receivedSentences).toContain("Now, I think I neeed to fix this bug.");
+	});
+});

--- a/src/editor/decorations.ts
+++ b/src/editor/decorations.ts
@@ -393,8 +393,29 @@ export function mapProblemsToPositions(
 		const sentenceIndex = problemWithSentence.sentenceIndex;
 		const targetSentence = sentences[sentenceIndex];
 
-		// Find the sentence in the extracted text
-		const sentenceStartInExtracted = extractedText.indexOf(targetSentence);
+		// The target sentence has punctuation added, but the extracted text doesn't.
+		// We need to find the original sentence in the extracted text.
+		// Remove the added punctuation to match what's in extractedText
+		const originalSentence = targetSentence.replace(/[.!?]+$/, "").trim();
+
+		// Find the original sentence in the extracted text
+		let sentenceStartInExtracted = extractedText.indexOf(originalSentence);
+
+		// If we can't find it with exact match, try a more flexible approach
+		if (sentenceStartInExtracted === -1) {
+			// Split extracted text into approximate sentences and find the best match
+			const extractedSentences = extractedText.split(/[.!?]\s+|\s+(?=[A-Z])/);
+			for (let i = 0; i < extractedSentences.length; i++) {
+				const extractedSent = extractedSentences[i].trim();
+				if (
+					extractedSent &&
+					(originalSentence.includes(extractedSent) || extractedSent.includes(originalSentence.substring(0, 20)))
+				) {
+					sentenceStartInExtracted = extractedText.indexOf(extractedSent);
+					break;
+				}
+			}
+		}
 
 		if (sentenceStartInExtracted === -1) {
 			continue;


### PR DESCRIPTION
This fix addresses the issue where sentences at the end of paragraphs without proper punctuation (ending with newlines) weren't being grammar checked.

Changes:
- Enhanced sentence splitting logic to detect collapsed newlines that represent sentence boundaries
- Fixed position mapping to handle sentences with added punctuation
- Added comprehensive test coverage for unterminated sentences
- Added fallback sentence matching for edge cases

The fix uses conservative heuristics to avoid false positives while ensuring sentences separated by newlines are properly detected and sent to the grammar checking API.

🤖 Generated with [Claude Code](https://claude.ai/code)