### PR TITLE
Refine correction modal workflow

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -157,7 +157,7 @@ The plugin will integrate directly with the **JetBrains AI Platform** using HTTP
   - Spelling errors: blue wavy underline (`text-decoration: underline wavy blue`)
   - Mixed errors: purple wavy underline for combined issues
   - Use CSS custom properties for theme-aware colors
-- [ ] **Create interactive correction modal**
+- [x] **Create interactive correction modal**
   - Implement `Modal` class extending Obsidian's `Modal`
   - Create side-by-side layout with original and corrected text
   - Add radio buttons for suggestion selection

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ The project is usable but still under active development. Core grammar checking 
 - Real-time error highlighting with incremental checks
 - Status bar spinner indicates active grammar checking
 - Hover tooltips and clickable suggestions
+- Interactive correction modal with side-by-side preview and bulk apply actions
 - Automatic grammar check when a file is opened
-- Manual check command available from the ribbon
+- Manual check command from the ribbon opens the review modal for applying suggestions
 - Language detection and sentence-level results are cached to reduce API usage
 
 ### Planned Features 🔄

--- a/src/editor/correction-modal.ts
+++ b/src/editor/correction-modal.ts
@@ -1,0 +1,276 @@
+import { App, Modal, Notice } from "obsidian";
+import { EditorView } from "@codemirror/view";
+import { GrammarProblemWithPosition, grammarDecorationsField, setGrammarProblems } from "./decorations";
+
+interface SuggestionSelection {
+	problem: GrammarProblemWithPosition;
+	suggestion: string;
+}
+
+export function problemHasSuggestions(problem: GrammarProblemWithPosition): boolean {
+	return extractSuggestions(problem).length > 0;
+}
+
+function extractSuggestions(problem: GrammarProblemWithPosition): string[] {
+	const suggestions: string[] = [];
+
+	for (const fix of problem.problem.fixes) {
+		const replacement = fix.parts
+			.filter(part => part.type === "Change" && typeof part.text === "string")
+			.map(part => part.text ?? "")
+			.join("");
+
+		if (replacement.trim().length > 0) {
+			suggestions.push(replacement);
+		}
+	}
+
+	return suggestions;
+}
+
+function formatProblemLabel(problem: GrammarProblemWithPosition, index: number): string {
+	const displayName = problem.problem.info.displayName?.trim();
+	const message = problem.problem.message?.trim();
+
+	if (displayName && message && displayName !== message) {
+		return `${index + 1}. ${displayName} – ${message}`;
+	}
+
+	if (displayName) {
+		return `${index + 1}. ${displayName}`;
+	}
+
+	if (message) {
+		return `${index + 1}. ${message}`;
+	}
+
+	return `${index + 1}. Suggested correction`;
+}
+
+export class CorrectionModal extends Modal {
+	private readonly selected = new Map<GrammarProblemWithPosition, string>();
+	private previewEl: HTMLTextAreaElement | null = null;
+	private readonly originalText: string;
+
+	constructor(
+		app: App,
+		private readonly view: EditorView,
+		private readonly problems: GrammarProblemWithPosition[]
+	) {
+		super(app);
+		this.originalText = this.view.state.doc.toString();
+	}
+
+	onOpen(): void {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.addClass("grazie-plugin-correction-modal");
+
+		const header = contentEl.createDiv({ cls: "grazie-plugin-correction-header" });
+		header.createEl("h2", { text: "Review suggestions" });
+		header.createSpan({
+			cls: "grazie-plugin-correction-summary",
+			text: `${this.problems.length} suggestion${this.problems.length === 1 ? "" : "s"} available`,
+		});
+
+		const panes = contentEl.createDiv("grazie-plugin-correction-panes");
+		const originalPane = panes.createDiv("grazie-plugin-original-pane");
+		const previewPane = panes.createDiv("grazie-plugin-preview-pane");
+
+		const originalTextArea = originalPane.createEl("textarea", {
+			cls: "grazie-plugin-original-text",
+		});
+		originalTextArea.readOnly = true;
+		originalTextArea.value = this.originalText;
+
+		this.previewEl = previewPane.createEl("textarea", {
+			cls: "grazie-plugin-preview-text",
+		});
+		this.previewEl.readOnly = true;
+		this.previewEl.value = this.originalText;
+
+		const problemsContainer = contentEl.createDiv("grazie-plugin-problems-container");
+
+		let hasAnySuggestions = false;
+
+		this.problems.forEach((problem, index) => {
+			const suggestions = extractSuggestions(problem);
+			if (suggestions.length === 0) {
+				return;
+			}
+
+			hasAnySuggestions = true;
+
+			const group = problemsContainer.createDiv("grazie-plugin-problem-group");
+			group.createDiv({
+				cls: "grazie-plugin-problem-heading",
+				text: formatProblemLabel(problem, index),
+			});
+
+			const context = group.createDiv("grazie-plugin-problem-context");
+			const originalSnippet = this.originalText.slice(problem.from, problem.to).trim();
+			context.setText(originalSnippet.length > 0 ? originalSnippet : "(No text highlighted)");
+
+			const options = group.createDiv("grazie-plugin-problem-options");
+
+			suggestions.forEach((suggestion, suggestionIndex) => {
+				const label = options.createEl("label", {
+					cls: "grazie-plugin-problem-option",
+				});
+				const radio = label.createEl("input", {
+					type: "radio",
+					attr: {
+						name: `grazie-problem-${index}`,
+						value: suggestion,
+					},
+				});
+				label.createSpan({
+					cls: "grazie-plugin-problem-option-text",
+					text: suggestion,
+				});
+
+				radio.addEventListener("change", () => {
+					this.selected.set(problem, suggestion);
+					this.updatePreview();
+				});
+
+				if (suggestionIndex === 0) {
+					radio.checked = true;
+					this.selected.set(problem, suggestion);
+				}
+			});
+
+			const keepOriginalLabel = options.createEl("label", {
+				cls: "grazie-plugin-problem-option",
+			});
+			const keepOriginalRadio = keepOriginalLabel.createEl("input", {
+				type: "radio",
+				attr: {
+					name: `grazie-problem-${index}`,
+					value: "grazie-keep-original",
+				},
+			});
+			keepOriginalLabel.createSpan({
+				cls: "grazie-plugin-problem-option-text",
+				text: "Keep original text",
+			});
+
+			keepOriginalRadio.addEventListener("change", () => {
+				this.selected.delete(problem);
+				this.updatePreview();
+			});
+		});
+
+		if (!hasAnySuggestions) {
+			const emptyState = contentEl.createDiv("grazie-plugin-correction-empty");
+			emptyState.setText("No automatic suggestions are available right now.");
+		}
+
+		const buttons = contentEl.createDiv("grazie-plugin-modal-buttons");
+		const applyAllBtn = buttons.createEl("button", {
+			cls: "grazie-plugin-primary-button",
+			text: "Apply all",
+		});
+		applyAllBtn.disabled = !hasAnySuggestions;
+		applyAllBtn.addEventListener("click", () => {
+			this.applyAll();
+		});
+
+		const applySelectedBtn = buttons.createEl("button", {
+			text: "Apply selected",
+		});
+		applySelectedBtn.addEventListener("click", () => {
+			this.applySelected();
+		});
+
+		const cancelBtn = buttons.createEl("button", {
+			text: "Cancel",
+		});
+		cancelBtn.addEventListener("click", () => {
+			this.close();
+		});
+
+		this.updatePreview();
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+	}
+
+	private updatePreview(): void {
+		if (!this.previewEl) {
+			return;
+		}
+
+		let preview = this.originalText;
+		const ordered = [...this.problems].filter(problem => this.selected.has(problem)).sort((a, b) => b.from - a.from);
+
+		for (const problem of ordered) {
+			const suggestion = this.selected.get(problem);
+			if (!suggestion) {
+				continue;
+			}
+
+			preview = `${preview.slice(0, problem.from)}${suggestion}${preview.slice(problem.to)}`;
+		}
+
+		this.previewEl.value = preview;
+	}
+
+	private applySelected(): void {
+		const selections: SuggestionSelection[] = [];
+
+		for (const problem of this.problems) {
+			const suggestion = this.selected.get(problem);
+			if (suggestion) {
+				selections.push({ problem, suggestion });
+			}
+		}
+
+		if (selections.length === 0) {
+			new Notice("Select at least one suggestion to apply.");
+			return;
+		}
+
+		const state = this.view.state.field(grammarDecorationsField, false);
+		const problemsToRemove = new Set(selections.map(selection => selection.problem));
+		const changes = selections
+			.sort((a, b) => a.problem.from - b.problem.from)
+			.map(selection => ({
+				from: selection.problem.from,
+				to: selection.problem.to,
+				insert: selection.suggestion,
+			}));
+
+		const effects = state
+			? [setGrammarProblems.of(state.problems.filter(problem => !problemsToRemove.has(problem)))]
+			: [];
+
+		this.view.dispatch({
+			changes,
+			effects,
+		});
+
+		this.close();
+	}
+
+	private applyAll(): void {
+		let hasSuggestion = false;
+
+		for (const problem of this.problems) {
+			const suggestions = extractSuggestions(problem);
+			if (suggestions.length > 0) {
+				this.selected.set(problem, suggestions[0]);
+				hasSuggestion = true;
+			}
+		}
+
+		if (!hasSuggestion) {
+			new Notice("No suggestions available to apply.");
+			return;
+		}
+
+		this.updatePreview();
+		this.applySelected();
+	}
+}

--- a/src/editor/realtime-check.ts
+++ b/src/editor/realtime-check.ts
@@ -136,7 +136,7 @@ function scheduleCheck(view: EditorView, plugin: GraziePlugin): void {
 					void plugin.checkRange(view, st.from, st.to);
 					view.dispatch({ effects: setRange.of(null) });
 				} else {
-					void plugin.checkCurrentFile();
+					void plugin.checkCurrentFile({ trigger: "auto" });
 				}
 			}
 		} catch (error) {

--- a/src/services/editor-decorator.ts
+++ b/src/services/editor-decorator.ts
@@ -19,11 +19,15 @@ export class EditorDecoratorService {
 	/**
 	 * Apply grammar checking results to an editor view
 	 */
-	async applyGrammarResults(view: EditorView, file: TFile, result: GrammarCheckResult): Promise<void> {
+	async applyGrammarResults(
+		view: EditorView,
+		file: TFile,
+		result: GrammarCheckResult
+	): Promise<GrammarProblemWithPosition[]> {
 		if (!result.hasErrors) {
 			// Clear existing decorations
 			this.clearDecorations(view);
-			return;
+			return [];
 		}
 
 		try {
@@ -45,8 +49,11 @@ export class EditorDecoratorService {
 
 			// Apply decorations
 			this.setDecorations(view, validProblems);
+
+			return validProblems;
 		} catch (error) {
 			console.error("Failed to apply grammar decorations:", error);
+			return [];
 		}
 	}
 

--- a/src/styles.src.css
+++ b/src/styles.src.css
@@ -153,3 +153,137 @@
 		opacity: 1;
 	}
 }
+
+/* Correction modal */
+.grazie-plugin-correction-modal {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	max-height: 75vh;
+	overflow: hidden;
+}
+
+.grazie-plugin-correction-header {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.grazie-plugin-correction-header h2 {
+	margin: 0;
+	font-size: 1.25em;
+	font-weight: 600;
+}
+
+.grazie-plugin-correction-summary {
+	color: var(--text-muted);
+	font-size: 0.9em;
+}
+
+.grazie-plugin-correction-panes {
+	display: flex;
+	gap: 8px;
+	height: 220px;
+}
+
+.grazie-plugin-original-pane,
+.grazie-plugin-preview-pane {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+}
+
+.grazie-plugin-original-text,
+.grazie-plugin-preview-text {
+	width: 100%;
+	height: 100%;
+	resize: none;
+}
+
+.grazie-plugin-problems-container {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	overflow-y: auto;
+	padding-right: 4px;
+}
+
+.grazie-plugin-problem-group {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 6px;
+	padding: 8px;
+	background: var(--background-secondary);
+}
+
+.grazie-plugin-problem-heading {
+	font-weight: 600;
+	color: var(--text-normal);
+}
+
+.grazie-plugin-problem-context {
+	font-size: 0.9em;
+	color: var(--text-muted);
+	background: var(--background-primary);
+	border-radius: 4px;
+	padding: 6px;
+	word-break: break-word;
+}
+
+.grazie-plugin-problem-options {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.grazie-plugin-problem-option {
+	display: flex;
+	align-items: flex-start;
+	gap: 6px;
+	font-size: 0.95em;
+	cursor: pointer;
+}
+
+.grazie-plugin-problem-option input[type="radio"] {
+	margin-top: 4px;
+}
+
+.grazie-plugin-problem-option-text {
+	flex: 1;
+	word-break: break-word;
+}
+
+.grazie-plugin-correction-empty {
+	color: var(--text-muted);
+	font-style: italic;
+	padding: 12px;
+}
+
+.grazie-plugin-modal-buttons {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	margin-top: 8px;
+}
+
+.grazie-plugin-modal-buttons button {
+	padding: 6px 12px;
+}
+
+.grazie-plugin-primary-button {
+	background: var(--interactive-accent);
+	border: none;
+	color: var(--text-on-accent);
+	transition: filter 0.2s ease;
+}
+
+.grazie-plugin-primary-button:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
+.grazie-plugin-primary-button:not(:disabled):hover {
+	filter: brightness(1.1);
+}


### PR DESCRIPTION
## Summary
- rebuild the correction modal with default selections, preview updates, and state cleanup when applying suggestions
- open the review modal from manual grammar checks by returning mapped problems from the decorator and surfacing actionable issues
- refresh the modal styling and documentation to describe the new review flow

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_687b849133008332add189b42f538ee6